### PR TITLE
Pluggable Pod Controller

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -356,6 +356,13 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val EXECUTOR_POD_CONTROLLER_CLASS =
+    ConfigBuilder("spark.kubernetes.executor.podController.class")
+      .doc("Experimental. Specify a class that can handle the creation " +
+        "and deletion of pods")
+      .stringConf
+      .createOptional
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SECRETS_PREFIX = "spark.kubernetes.driver.secrets."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodController.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodController.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import java.util
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.KubernetesClient
+
+
+/**
+ * Responsible for the creation and deletion of Pods as per the
+ * request of the ExecutorPodAllocator, ExecutorPodLifecycleManager, and the
+ * KubernetesClusterSchedulerBackend. The default implementation:
+ * ExecutorPodControllerImpl communicates directly
+ * with the KubernetesClient to create Pods. This class can be extended
+ * to have your communication be done with a unique CRD that satisfies
+ * your specific SLA and security concerns.
+ */
+private[spark] trait ExecutorPodController {
+
+  def initialize(kubernetesClient: KubernetesClient): Unit
+
+  def addPod(pod: Pod): Unit
+
+  def commitAndGetTotalAllocated(): Int
+
+  def removePod(pod: Pod): Unit
+
+  def removePods(pods: util.List[Pod]): Boolean
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerImpl.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerImpl.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import java.util
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.KubernetesClient
+
+import org.apache.spark.SparkConf
+import org.apache.spark.util.Utils
+
+private[spark] class ExecutorPodControllerImpl(
+    val conf: SparkConf)
+  extends ExecutorPodController {
+
+  private var kubernetesClient: KubernetesClient = _
+
+  private var numAdded: Int = _
+
+  override def initialize(kClient: KubernetesClient) : Unit = {
+    kubernetesClient = kClient
+    numAdded = 0
+  }
+  override def addPod(pod: Pod): Unit = {
+    kubernetesClient.pods().create(pod)
+    synchronized {
+      numAdded += 1
+    }
+  }
+
+  override def commitAndGetTotalAllocated(): Int = {
+    val totalNumAdded = numAdded
+    synchronized {
+      numAdded = 0
+    }
+    totalNumAdded
+  }
+
+  override def removePod(pod: Pod): Unit = {
+    // If deletion failed on a previous try, we can try again if resync informs us the pod
+    // is still around.
+    // Delete as best attempt - duplicate deletes will throw an exception but the end state
+    // of getting rid of the pod is what matters.
+    Utils.tryLogNonFatalError {
+      kubernetesClient
+        .pods()
+        .withName(pod.getMetadata.getName)
+        .delete()
+    }
+  }
+
+  override def removePods(pods: util.List[Pod]): Boolean = {
+    kubernetesClient.pods().delete(pods)
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -22,13 +22,13 @@ import java.util.concurrent.TimeUnit
 import com.google.common.cache.CacheBuilder
 import io.fabric8.kubernetes.client.Config
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkKubernetesClientFactory}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{ExternalClusterManager, SchedulerBackend, TaskScheduler, TaskSchedulerImpl}
-import org.apache.spark.util.{SystemClock, ThreadUtils}
+import org.apache.spark.util.{SystemClock, ThreadUtils, Utils}
 
 private[spark] class KubernetesClusterManager extends ExternalClusterManager with Logging {
 
@@ -98,10 +98,26 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     val removedExecutorsCache = CacheBuilder.newBuilder()
       .expireAfterWrite(3, TimeUnit.MINUTES)
       .build[java.lang.Long, java.lang.Long]()
+
+    val executorPodControllers = sc.conf.get(EXECUTOR_POD_CONTROLLER_CLASS)
+      .map(clazz => Utils.loadExtensions(
+        classOf[ExecutorPodController],
+        Seq(clazz), sc.conf))
+      .getOrElse(Seq(new ExecutorPodControllerImpl(sc.conf)))
+
+    if (executorPodControllers.size > 1) {
+      throw new SparkException(
+        s"Multiple executorPodControllers listed: $executorPodControllers")
+    }
+    val executorPodController = executorPodControllers.head
+
+    executorPodController.initialize(kubernetesClient)
+
     val executorPodsLifecycleEventHandler = new ExecutorPodsLifecycleManager(
       sc.conf,
       kubernetesClient,
       snapshotsStore,
+      executorPodController,
       removedExecutorsCache)
 
     val executorPodsAllocator = new ExecutorPodsAllocator(
@@ -110,6 +126,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       new KubernetesExecutorBuilder(),
       kubernetesClient,
       snapshotsStore,
+      executorPodController,
       new SystemClock())
 
     val podsWatchEventSource = new ExecutorPodsWatchSnapshotSource(
@@ -129,6 +146,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       snapshotsStore,
       executorPodsAllocator,
       executorPodsLifecycleEventHandler,
+      executorPodController,
       podsWatchEventSource,
       podsPollingEventSource)
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import io.fabric8.kubernetes.api.model.{DoneablePod, Pod, PodBuilder}
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.dsl.PodResource
+import org.mockito.{Mock, MockitoAnnotations}
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.BeforeAndAfter
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.Fabric8Aliases.PODS
+
+class ExecutorPodControllerSuite extends SparkFunSuite with BeforeAndAfter {
+
+  private var executorPodController: ExecutorPodController = _
+
+  private val sparkConf = new SparkConf(false)
+
+  private val execExampleId = "exec-id"
+
+  private def buildPod(execId: String ): Pod = {
+    new PodBuilder()
+      .withNewMetadata()
+      .withName(execId)
+      .endMetadata()
+      .build()
+  }
+
+  private val execPod = buildPod(execExampleId)
+
+  @Mock
+  private var kubernetesClient: KubernetesClient = _
+
+  @Mock
+  private var podOperations: PODS = _
+
+  @Mock
+  private var execPodOperations: PodResource[Pod, DoneablePod] = _
+
+
+  before {
+    MockitoAnnotations.initMocks(this)
+    when(kubernetesClient.pods()).thenReturn(podOperations)
+    when(podOperations.withName(execExampleId))
+        .thenReturn(execPodOperations)
+    executorPodController = new ExecutorPodControllerImpl(sparkConf)
+    executorPodController.initialize(kubernetesClient)
+  }
+
+  test("Adding a pod and watching counter go up correctly") {
+    val numAllocated = 5
+    for ( _ <- 0 until numAllocated) {
+      executorPodController.addPod(execPod)
+    }
+    verify(podOperations, times(numAllocated)).create(execPod)
+    assert(executorPodController.commitAndGetTotalAllocated() == numAllocated)
+    assert(executorPodController.commitAndGetTotalAllocated() == 0)
+    executorPodController.addPod(execPod)
+    assert(executorPodController.commitAndGetTotalAllocated() == 1)
+  }
+
+  test("Remove a single pod") {
+    executorPodController.removePod(execPod)
+    verify(execPodOperations).delete()
+  }
+
+  test("Remove a list of pods") {
+    val execList = (1 to 3).map { num =>
+      buildPod(s"$execExampleId-$num")
+    }
+    executorPodController.removePods(execList.asJava)
+    verify(podOperations).delete(execList.asJava)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This introduces a pluggable API for creating and remove pods in a way beyond calling `kubernetes.pods().create/delete`.

## How was this patch tested?

- [x] Unit Tests
- [x] Integration Tests
